### PR TITLE
read executed line to get indentation level and expand code

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,24 +8,88 @@ Compatibility:
 * [Hydrogen](https://github.com/nteract/hydrogen) version 2.3.0 or later
 * Variable explorer has only been tested to work with Python 3.5 or later. Pull requests to add Python 2 support are welcome.
 
-## Feature: Strip common leading whitespace
-
-Lets you select and run code blocks that are indented (e.g. inside a function). No configuration needed.
-
-Example:
-
-```python
-def foo():
-    x = 1
-    print('x is', x)
-    # Select the above two lines and run them with Hydrogen!
-```
-
-There is also an experimental option to expand the code passed on by hydrogen to include else/elif or closing brackets, which until now is only possible when selecting the code.
-However, the tick mark can not be moved to the right location as of yet.
-
 ## Feature: Variable Explorer
 
 Activate using the _"Hydrogen Python: Toggle Variable Explorer"_ command.
 
 This feature is currently in proof-of-concept status. Please file an issue about any functionality you want to have in the variable exploror!
+
+## Feature: Extend Executable Code [experimental]
+
+When a line is executed without selection, hydrogen only passes on code up that is indented compared to the current line.
+In python that unfortunately does not always work, because some control structures (e.g. else) continue on the same indentation level.
+For example, the following code block would only execute the `if` statement, but not the `else` statement when the `Run and Move Down` or the `Run` commands are used.
+
+```python
+if False:
+    print('False')
+else:
+    print('True')
+# with `Run` or `Run and Move Down`
+# there is no output in standard hydrogen
+# as the else block is not included
+```
+
+Enabling the setting `Extend Executable Code` (by default it is disabled!) expands the executed code beyond what hydrogen suggests on the basis of the indentation level.
+A list of strings for which the code is extended can be defined.
+In the default setting, `else`, `elif`, `except`, `finally`, as well as all closing braces are included in the expansion.
+
+**Warning:** Note with all this, that as of now the hydrogen tick markers are unfortunately _not_ moved to the right location. They still remain where the original code selection of hydrogen ended.
+
+When enabling the setting, examples like the following should work as expected:
+
+```python
+someDictionary = {
+    'one': 1
+}
+
+someList = [
+    1,
+    2,
+    3
+]
+
+foo(
+    argument1,
+    argument2
+)
+# in hydrogen each of these would throw an error
+# because the closing brace is not included
+# as it is on the same indentation level
+```
+
+```python
+if False:
+    pass
+elif False:
+    pass
+else:
+    print('executed')
+# in hydrogen this would only execute the
+# if-statement as elif and else are not extended
+```
+
+```python
+try:
+    throw(IndentationError)
+except:
+    print('some error occurred')
+finally:
+    print('finally')
+# in hydrogen this would only raise an error but not
+# execute the except and finally blocks
+```
+
+### Customisation
+
+You can extend this list by your choice.
+Make sure you check that the behaviour has no unintended circumstances;
+`hydrogen-python` logs to the console when code is extended.
+One possibly useful addition can be to add `plt\.` to the list, so that the following code block can be run without having to select lines independently:
+
+```python
+plt.plot()
+plt.xlabel()
+plt.ylabel()
+plt.show()
+```

--- a/README.md
+++ b/README.md
@@ -21,23 +21,8 @@ def foo():
     # Select the above two lines and run them with Hydrogen!
 ```
 
-### Limitations
-
-Does not work if the first line ends in `:` and you have a comment after, i.e.
-
-```python
-if True: # having a comment here breaks things
-    print("This doesn't work!")
-```
-
-It also can have unexpected results if you select some code that is malformed to begin with, e.g.
-
-```python
-x = 1
-    print("x is", x) # This works even though it shouldn't
-```
-
-(Pull requests are welcome to fix the first issue; the second probably can't be fixed without changing the Hydrogen package)
+There is also an experimental option to expand the code passed on by hydrogen to include else/elif or closing brackets, which until now is only possible when selecting the code.
+However, the tick mark can not be moved to the right location as of yet.
 
 ## Feature: Variable Explorer
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,32 @@ finally:
 # execute the except and finally blocks
 ```
 
+### Extension to the Top (e.g. for decorators)
+
+In the second configuration field, expansion towards the top is defined.
+The preset is to extends decorators (`@`) of functions, so that the following example works when selecting either the line with the decorator or with the function definition and executing via `run` or `run-and-move-down`.
+
+```python
+def deco(f):
+    return lambda x: f(x + 1)
+
+@deco
+def myfunc(x):
+    return 1 / x
+
+myfunc(0)
+```
+
+Contrary to the expansion to the bottom, this _does not_ automatically include comments, or further indentation, but only the immediate match.
+The following example thus would not work with the default settings, but could easily be enabled by adding `#` to the list:
+
+```python
+@deco
+# comment
+def myfunc(x):
+    return 1 / x
+```
+
 ### Customisation
 
 You can extend this list by your choice.

--- a/lib/main.js
+++ b/lib/main.js
@@ -82,22 +82,31 @@ class PythonKernelMod {
     // read editor settings
     const e = atom.workspace.getActiveTextEditor();
     const selection = e.getSelectedBufferRange();
+    const isSelection = !selection.start.isEqual(selection.end);
+    const isRunWithoutMove = (e.lineTextForBufferRow(selection.start.row) || '').includes(code.split('\n', 1)[0]);
+    const isRunWithMove = (e.lineTextForBufferRow(selection.start.row - code.split('\n').length) || '').includes(code.split('\n', 1)[0]);
+    if ((!isRunWithoutMove && !isRunWithMove) || isRunWithMove == isRunWithoutMove) {
+      console.warn('[hydrogen-python] Could not identify run-type properly.');
+    }
+
+    console.log(selection.start.row, isRunWithoutMove, (isRunWithoutMove) ? 0 : (code.split('\n').length - 1), code.split('\n').length);
+
+    const startBufferRow = selection.start.row - ((isRunWithoutMove) ? 0 : (code.split('\n').length));
     const tabSub = ' '.repeat(e.getTabLength());
 
     // prepend original indent to code
-    let indent = e.lineTextForBufferRow(selection.start.row).match(/^\s+/) || '';
+    let indent = e.lineTextForBufferRow(startBufferRow).match(/^\s+/) || '';
     code = indent + code;
     code = code.replace(/\t/g, tabSub);
 
     // expand code to cover closing brackets and else/elif
-    if (selection.start.isEqual(selection.end) &&
+    if (!isSelection &&
         atom.config.get('hydrogen-python.expandCode').length > 0) {
-      let lastRow = selection.start.row + (code.split('\n').length - 1);
+      let lastRow = startBufferRow + (code.split('\n').length - 1);
       const origRow = lastRow;
       let nextRowText = e.lineTextForBufferRow(lastRow + 1).replace(/\t/g, tabSub);
       const expandCode = [' '].concat(atom.config.get('hydrogen-python.expandCode')).join('|');
       while (nextRowText.match(new RegExp(`^${indent}(${expandCode})`))) {
-        console.log(nextRowText);
         code += `\n${nextRowText}`;
         lastRow += 1;
         nextRowText = e.lineTextForBufferRow(lastRow + 1).replace(/\t/g, tabSub);
@@ -111,6 +120,12 @@ class PythonKernelMod {
         if (indent === undefined) indent = match;
         return match.replace(indent, '');
       });
+    }
+
+    if (isRunWithMove) {
+      let bufferRow = startBufferRow + code.split('\n').length;
+      while (e.lineTextForBufferRow(bufferRow).match(/^\s*($|#)/)) { bufferRow += 1; }
+      e.setCursorBufferPosition([bufferRow, 0]);
     }
 
     next.execute(code, (msg, channel) => {

--- a/lib/main.js
+++ b/lib/main.js
@@ -79,36 +79,35 @@ class PythonKernelMod {
   execute(next, code, onResults) {
     let makeReply = null;
 
-    // trim right to avoid empty lines at the end of the selection
-    code = code.trimRight();
-
-    // read editor settings
     const e = atom.workspace.getActiveTextEditor();
     const selection = e.getSelectedBufferRange();
     const isSelection = !selection.start.isEqual(selection.end);
-    const isRunWithoutMove = (e.lineTextForBufferRow(selection.start.row) || '').includes(code.split('\n', 1)[0]);
+    if (atom.config.get('hydrogen-python.expandCode') && !isSelection) {
+    // trim right to avoid empty lines at the end of the selection
+      code = code.trimRight();
 
-    // find start of executed code
-    let startBufferRow = selection.start.row;
-    if (!isRunWithoutMove) {
-      const lastCodeLine = code.split('\n')[code.split('\n').length - 1];
-      while (!e.lineTextForBufferRow(startBufferRow).includes(lastCodeLine)) {
-        startBufferRow -= 1;
-        if (startBufferRow < 0) break;
+      // read editor settings
+      const isRunWithoutMove = (e.lineTextForBufferRow(selection.start.row) || '').includes(code.split('\n', 1)[0]);
+
+      // find start of executed code
+      let startBufferRow = selection.start.row;
+      if (!isRunWithoutMove) {
+        const lastCodeLine = code.split('\n')[code.split('\n').length - 1];
+        while (!e.lineTextForBufferRow(startBufferRow).includes(lastCodeLine)) {
+          startBufferRow -= 1;
+          if (startBufferRow < 0) break;
+        }
+        startBufferRow = Math.max(0, startBufferRow - code.split('\n').length + 1);
       }
-      startBufferRow = Math.max(0, startBufferRow - code.split('\n').length + 1);
-    }
 
-    // find original indent
-    const indent = (code.match(/^\s+/) || '');
+      // find original indent
+      const indent = (code.match(/^\s+/) || '');
 
-    // expand code if not a selection and item set
-    if (!isSelection &&
-        atom.config.get('hydrogen-python.expandCode').length > 0) {
+      // expand code if not a selection and item set
       let lastRow = startBufferRow + (code.split('\n').length - 1);
       const origRow = lastRow;
       let nextRowText = (e.lineTextForBufferRow(lastRow + 1) || '');
-      const expandCode = [' '].concat(atom.config.get('hydrogen-python.expandCode')).join('|');
+      const expandCode = [' '].concat(atom.config.get('hydrogen-python.expandCodeList')).join('|');
       const re = new RegExp(`^(${indent}(${expandCode})|\s*#|\s*$)`);
       while (nextRowText.match(re)) {
         code += `\n${nextRowText}`;
@@ -117,13 +116,13 @@ class PythonKernelMod {
         nextRowText = e.lineTextForBufferRow(lastRow + 1);
       }
       if (origRow < lastRow) { console.log(`[hydrogen-python] expanded code by ${lastRow - origRow} lines up to line ${lastRow + 1}`); }
-    }
 
-    // if run-and-move set cursor to the beginning of the next content line
-    if (!isRunWithoutMove) {
-      let bufferRow = startBufferRow + code.split('\n').length;
-      while (bufferRow < e.getLineCount() && (e.lineTextForBufferRow(bufferRow) || '').match(/^\s*($|#)/)) { bufferRow += 1; }
-      e.setCursorBufferPosition([(bufferRow == startBufferRow) ? (bufferRow + 1) : (bufferRow), 0]);
+      // if run-and-move set cursor to the beginning of the next content line
+      if (!isRunWithoutMove) {
+        let bufferRow = startBufferRow + code.split('\n').length;
+        while (bufferRow < e.getLineCount() && (e.lineTextForBufferRow(bufferRow) || '').match(/^\s*($|#)/)) { bufferRow += 1; }
+        e.setCursorBufferPosition([(bufferRow == startBufferRow) ? (bufferRow + 1) : (bufferRow), 0]);
+      }
     }
 
     next.execute(code, (msg, channel) => {

--- a/lib/main.js
+++ b/lib/main.js
@@ -74,16 +74,6 @@ function expandCode(editor, code) {
    editor.lineTextForBufferRow(
      Math.min(selection.start.row + code.split('\n').length - 1,
        bufferRowLength)).trimRight() === lastCodeLineText);
-  console.log('=====');
-  console.log(editor.lineTextForBufferRow(
-    Math.min(selection.start.row + code.split('\n').length - 1,
-      bufferRowLength)).trimRight());
-  console.log(lastCodeLineText);
-  console.log(code.includes(cursorLineText),
-    editor.lineTextForBufferRow(
-      Math.min(selection.start.row + code.split('\n').length - 1,
-        bufferRowLength)).trimRight() === lastCodeLineText);
-  console.log(isRunWithoutMove);
 
   // find start of executed code
   let startBufferRow = selection.start.row;

--- a/lib/main.js
+++ b/lib/main.js
@@ -87,7 +87,7 @@ class PythonKernelMod {
       code = code.trimRight();
 
       // read editor settings
-      const isRunWithoutMove = (e.lineTextForBufferRow(selection.start.row) || '').includes(code.split('\n', 1)[0]);
+      const isRunWithoutMove = code.includes(e.lineTextForBufferRow(selection.start.row).trim());
 
       // find start of executed code
       let startBufferRow = selection.start.row;
@@ -109,7 +109,12 @@ class PythonKernelMod {
       let nextRowText = (e.lineTextForBufferRow(lastRow + 1) || '');
       const expandCode = [' '].concat(atom.config.get('hydrogen-python.expandCodeList')).join('|');
       const re = new RegExp(`^(${indent}(${expandCode})|\s*#|\s*$)`);
-      while (nextRowText.match(re)) {
+      const isBreakpoint = rownum => e.tokensForScreenRow(rownum).reduce((l, t) =>
+        t.scopes.reduce((ll, tt) =>
+          tt.split(' ').concat(ll), [],
+        ).concat(l), []).includes('syntax--breakpoint');
+
+      while (!isBreakpoint(lastRow) && nextRowText.match(re)) {
         code += `\n${nextRowText}`;
         lastRow += 1;
         if (lastRow + 1 > e.getLastBufferRow()) break;

--- a/lib/main.js
+++ b/lib/main.js
@@ -109,11 +109,10 @@ class PythonKernelMod {
       const expandCode = [' '].concat(atom.config.get('hydrogen-python.expandCodeList')).join('|');
       const re = new RegExp(`^(${indent}(${expandCode})|\s*#|\s*$)`);
       const isBreakpoint = rownum =>
-        e.tokenizedBuffer.tokenizedLines[rownum].tokens.reduce((l, t) =>
-          t.scopes.reduce((ll, tt) =>
-            tt.split(' ').concat(ll), [],
-          ).concat(l), []).filter(t =>
-          t.endsWith('.breakpoint'),
+        e.tokenizedBuffer.tokenizedLines[rownum].tokens.reduce(
+          (l, t) => t.scopes.concat(l), [],
+        ).filter(
+          t => t.endsWith('.breakpoint'),
         ).length > 0;
 
       while (lastRow < e.getLineCount() && !isBreakpoint(lastRow) && nextRowText.match(re)) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -79,20 +79,38 @@ class PythonKernelMod {
   execute(next, code, onResults) {
     let makeReply = null;
 
-    // Simple attempt to strip common leading whitespace
-    let firstLine = code.split('\n', 1)[0];
-    let remainingLines = code.slice(firstLine.length + 1);
+    // read editor settings
+    const e = atom.workspace.getActiveTextEditor();
+    const selection = e.getSelectedBufferRange();
+    const tabSub = ' '.repeat(e.getTabLength());
 
-    if (remainingLines.length > 0) {
-      let rest = stripIndent(remainingLines);
-      if (rest != remainingLines) {
-        let firstTrimmed = firstLine.trim();
-        // Strip leading whitespace, only if first line does not end in ":"
-        // XXX(nikita): doesn't handle comments on first line and other edge cases
-        if (firstTrimmed.length > 0 && firstTrimmed[firstTrimmed.length - 1] != ":") {
-            code = firstLine + "\n" + rest;
-        }
+    // prepend original indent to code
+    let indent = e.lineTextForBufferRow(selection.start.row).match(/^\s+/) || '';
+    code = indent + code;
+    code = code.replace(/\t/g, tabSub);
+
+    // expand code to cover closing brackets and else/elif
+    if (selection.start.isEqual(selection.end) &&
+        atom.config.get('hydrogen-python.expandCode').length > 0) {
+      let lastRow = selection.start.row + (code.split('\n').length - 1);
+      const origRow = lastRow;
+      let nextRowText = e.lineTextForBufferRow(lastRow + 1).replace(/\t/g, tabSub);
+      const expandCode = [' '].concat(atom.config.get('hydrogen-python.expandCode')).join('|');
+      while (nextRowText.match(new RegExp(`^${indent}(${expandCode})`))) {
+        console.log(nextRowText);
+        code += `\n${nextRowText}`;
+        lastRow += 1;
+        nextRowText = e.lineTextForBufferRow(lastRow + 1).replace(/\t/g, tabSub);
       }
+      if (origRow < lastRow) { console.log(`[hydrogen-python] expanded code by ${lastRow - origRow} lines up to line ${lastRow + 1}`); }
+    }
+
+    // strip all indentation
+    if (indent) {
+      code = code.replace(/(^\s+)/gm, (match) => {
+        if (indent === undefined) indent = match;
+        return match.replace(indent, '');
+      });
     }
 
     next.execute(code, (msg, channel) => {

--- a/lib/main.js
+++ b/lib/main.js
@@ -55,6 +55,88 @@ function codeFromFile(filename) {
   return `exec('''${contents}''', globals().copy())`;
 }
 
+function expandCode(editor, code) {
+  const selection = editor.getSelectedBufferRange();
+  const isSelection = !selection.start.isEqual(selection.end);
+  // if there is a selection, we don't need to expand the code
+  if (isSelection) {
+    return code;
+  }
+
+  const bufferRowLength = editor.getLastBufferRow();
+
+  // trim right to avoid empty lines at the end of the selection
+  code = code.trimRight();
+
+  const cursorLineText = editor.lineTextForBufferRow(selection.start.row);
+  const lastCodeLineText = code.split('\n')[code.split('\n').length - 1];
+  const isRunWithoutMove = (code.includes(cursorLineText) &&
+   editor.lineTextForBufferRow(
+     Math.min(selection.start.row + code.split('\n').length - 1,
+       bufferRowLength)).trimRight() === lastCodeLineText);
+  console.log('=====');
+  console.log(editor.lineTextForBufferRow(
+    Math.min(selection.start.row + code.split('\n').length - 1,
+      bufferRowLength)).trimRight());
+  console.log(lastCodeLineText);
+  console.log(code.includes(cursorLineText),
+    editor.lineTextForBufferRow(
+      Math.min(selection.start.row + code.split('\n').length - 1,
+        bufferRowLength)).trimRight() === lastCodeLineText);
+  console.log(isRunWithoutMove);
+
+  // find start of executed code
+  let startBufferRow = selection.start.row;
+  if (!isRunWithoutMove) {
+    while (!editor.lineTextForBufferRow(startBufferRow).includes(lastCodeLineText)) {
+      startBufferRow -= 1;
+      if (startBufferRow < 0) break;
+    }
+    startBufferRow = Math.max(0, startBufferRow - code.split('\n').length + 1);
+  }
+
+  // find original indent
+  const indent = (code.match(/^\s+/) || '');
+
+  // function to identify breakpoints via tokens
+  const isBreakpoint = rownum =>
+    editor.tokenizedBuffer.tokenizedLines[rownum].tokens.reduce(
+      (accumulated, token) => token.scopes.concat(accumulated),
+      [],
+    ).filter(
+      token => token.endsWith('.breakpoint'),
+    ).length > 0;
+
+  // prepare expansion regex to the bottom
+  const expandCodeList = atom.config.get('hydrogen-python.expandCodeList');
+  // add whitespace to the list
+  const expandCode = ['\\s'].concat(expandCodeList).join('|');
+  const expandRegex = new RegExp(`^(${indent}(${expandCode})|\s*#|\s*$)`);
+
+  let lastRow = startBufferRow + (code.split('\n').length - 1);
+  const origRow = lastRow;
+  let nextRowText = (editor.lineTextForBufferRow(lastRow + 1) || '');
+
+  // expand code to the bottom
+  while (lastRow <= bufferRowLength && !isBreakpoint(lastRow) && nextRowText.match(expandRegex)) {
+    code += `\n${nextRowText}`;
+    lastRow += 1;
+    if (lastRow + 1 > editor.getLastBufferRow()) break;
+    nextRowText = editor.lineTextForBufferRow(lastRow + 1);
+  }
+  if (origRow < lastRow) { console.log(`[hydrogen-python] expanded code by ${lastRow - origRow} lines up to line ${lastRow + 1}`); }
+
+  // if run-and-move set cursor to the beginning of the next content line
+  if (!isRunWithoutMove) {
+    let bufferRow = startBufferRow + code.split('\n').length;
+    while (bufferRow <= bufferRowLength && (editor.lineTextForBufferRow(bufferRow) || '').match(/^\s*($|#)/)) { bufferRow += 1; }
+    editor.setCursorBufferPosition([(bufferRow == startBufferRow) ? (bufferRow + 1) : (bufferRow), 0]);
+  }
+  console.log(code);
+
+  return code;
+}
+
 class PythonKernelMod {
   constructor(kernel, emitter) {
     this.kernel = kernel;
@@ -78,57 +160,9 @@ class PythonKernelMod {
   execute(next, code, onResults) {
     let makeReply = null;
 
-    const e = atom.workspace.getActiveTextEditor();
-    const selection = e.getSelectedBufferRange();
-    const isSelection = !selection.start.isEqual(selection.end);
-    if (atom.config.get('hydrogen-python.expandCode') && !isSelection) {
-    // trim right to avoid empty lines at the end of the selection
-      code = code.trimRight();
-
-      // read editor settings
-      const isRunWithoutMove = code.includes(e.lineTextForBufferRow(selection.start.row).trim()) || e.lineTextForBufferRow(selection.start.row).match(/^\s+#/);
-
-      // find start of executed code
-      let startBufferRow = selection.start.row;
-      if (!isRunWithoutMove) {
-        const lastCodeLine = code.split('\n')[code.split('\n').length - 1];
-        while (!e.lineTextForBufferRow(startBufferRow).includes(lastCodeLine)) {
-          startBufferRow -= 1;
-          if (startBufferRow < 0) break;
-        }
-        startBufferRow = Math.max(0, startBufferRow - code.split('\n').length + 1);
-      }
-
-      // find original indent
-      const indent = (code.match(/^\s+/) || '');
-
-      // expand code if not a selection and item set
-      let lastRow = startBufferRow + (code.split('\n').length - 1);
-      const origRow = lastRow;
-      let nextRowText = (e.lineTextForBufferRow(lastRow + 1) || '');
-      const expandCode = [' '].concat(atom.config.get('hydrogen-python.expandCodeList')).join('|');
-      const re = new RegExp(`^(${indent}(${expandCode})|\s*#|\s*$)`);
-      const isBreakpoint = rownum =>
-        e.tokenizedBuffer.tokenizedLines[rownum].tokens.reduce(
-          (l, t) => t.scopes.concat(l), [],
-        ).filter(
-          t => t.endsWith('.breakpoint'),
-        ).length > 0;
-
-      while (lastRow < e.getLineCount() && !isBreakpoint(lastRow) && nextRowText.match(re)) {
-        code += `\n${nextRowText}`;
-        lastRow += 1;
-        if (lastRow + 1 > e.getLastBufferRow()) break;
-        nextRowText = e.lineTextForBufferRow(lastRow + 1);
-      }
-      if (origRow < lastRow) { console.log(`[hydrogen-python] expanded code by ${lastRow - origRow} lines up to line ${lastRow + 1}`); }
-
-      // if run-and-move set cursor to the beginning of the next content line
-      if (!isRunWithoutMove) {
-        let bufferRow = startBufferRow + code.split('\n').length;
-        while (bufferRow < e.getLineCount() && (e.lineTextForBufferRow(bufferRow) || '').match(/^\s*($|#)/)) { bufferRow += 1; }
-        e.setCursorBufferPosition([(bufferRow == startBufferRow) ? (bufferRow + 1) : (bufferRow), 0]);
-      }
+    if (atom.config.get('hydrogen-python.expandCode')) {
+      const editor = atom.workspace.getActiveTextEditor();
+      code = expandCode(editor, code);
     }
 
     next.execute(code, (msg, channel) => {

--- a/lib/main.js
+++ b/lib/main.js
@@ -87,7 +87,7 @@ class PythonKernelMod {
       code = code.trimRight();
 
       // read editor settings
-      const isRunWithoutMove = code.includes(e.lineTextForBufferRow(selection.start.row).trim());
+      const isRunWithoutMove = code.includes(e.lineTextForBufferRow(selection.start.row).trim()) || e.lineTextForBufferRow(selection.start.row).match(/^\s+#/);
 
       // find start of executed code
       let startBufferRow = selection.start.row;

--- a/lib/main.js
+++ b/lib/main.js
@@ -89,8 +89,6 @@ class PythonKernelMod {
       console.warn('[hydrogen-python] Could not identify run-type properly.');
     }
 
-    console.log(selection.start.row, isRunWithoutMove, (isRunWithoutMove) ? 0 : (code.split('\n').length - 1), code.split('\n').length);
-
     const startBufferRow = selection.start.row - ((isRunWithoutMove) ? 0 : (code.split('\n').length));
     const tabSub = ' '.repeat(e.getTabLength());
 
@@ -124,7 +122,7 @@ class PythonKernelMod {
 
     if (isRunWithMove) {
       let bufferRow = startBufferRow + code.split('\n').length;
-      while (e.lineTextForBufferRow(bufferRow).match(/^\s*($|#)/)) { bufferRow += 1; }
+      while (bufferRow < e.getLineCount() && (e.lineTextForBufferRow(bufferRow) || '').match(/^\s*($|#)/)) { bufferRow += 1; }
       e.setCursorBufferPosition([bufferRow, 0]);
     }
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,14 +1,14 @@
 'use babel';
 
 import { CompositeDisposable, Disposable, Emitter } from 'atom';
-import React from "react";
-import ReactDOM from "react-dom";
-import v4 from "uuid/v4";
+import React from 'react';
+import ReactDOM from 'react-dom';
+import v4 from 'uuid/v4';
 import stripIndent from 'strip-indent';
-import fs from "fs";
-import path from "path";
+import fs from 'fs';
+import path from 'path';
 
-import VariableExplorer from "./variable-explorer";
+import VariableExplorer from './variable-explorer';
 
 // Should be unique among all plugins. At some point, hydrogen should provide
 // an API that doesn't require adding fields to the kernel wrappers.
@@ -26,20 +26,19 @@ function _getUsername() {
 }
 
 function createMessageFactory(parent_header) {
-  return (type) => {
-    return {
-      header: {
-        username: _getUsername(),
-        session: parent_header.session, // check if this is correct
-        msg_type: type,
-        msg_id: v4(),
-        date: new Date(),
-        version: "5.0"
-      },
-      metadata: {},
-      parent_header: parent_header,
-      content: {}
-  }};
+  return type => ({
+    header: {
+      username: _getUsername(),
+      session: parent_header.session, // check if this is correct
+      msg_type: type,
+      msg_id: v4(),
+      date: new Date(),
+      version: '5.0',
+    },
+    metadata: {},
+    parent_header,
+    content: {},
+  });
 }
 
 function codeFromFile(filename) {
@@ -48,12 +47,12 @@ function codeFromFile(filename) {
   // gets called on, so to avoid escaping issues we mandate that the files not
   // contain ''' anywhere.
   const fullPath = path.join(__dirname, '..', 'py', filename);
-  var contents = fs.readFileSync(fullPath, 'utf8');
-  if(contents.includes("'''")) {
+  const contents = fs.readFileSync(fullPath, 'utf8');
+  if (contents.includes("'''")) {
     throw new Error(`File ${filename} contains triple single-quotes`);
   }
 
-  return `exec('''${contents}''', globals().copy())`
+  return `exec('''${contents}''', globals().copy())`;
 }
 
 class PythonKernelMod {
@@ -69,9 +68,9 @@ class PythonKernelMod {
 
     this.enableVariableExplorer = false;
     this.subscriptions.add(
-      this.emitter.on('did-show-explorer', ()=>{
+      this.emitter.on('did-show-explorer', () => {
         this.enableVariableExplorer = true;
-      })
+      }),
     );
     this.emitter.emit('did-install-middleware');
   }
@@ -109,10 +108,13 @@ class PythonKernelMod {
       let nextRowText = (e.lineTextForBufferRow(lastRow + 1) || '');
       const expandCode = [' '].concat(atom.config.get('hydrogen-python.expandCodeList')).join('|');
       const re = new RegExp(`^(${indent}(${expandCode})|\s*#|\s*$)`);
-      const isBreakpoint = rownum => e.tokensForScreenRow(rownum).reduce((l, t) =>
-        t.scopes.reduce((ll, tt) =>
-          tt.split(' ').concat(ll), [],
-        ).concat(l), []).includes('syntax--breakpoint');
+      const isBreakpoint = rownum =>
+        e.tokenizedBuffer.tokenizedLines[rownum].tokens.reduce((l, t) =>
+          t.scopes.reduce((ll, tt) =>
+            tt.split(' ').concat(ll), [],
+          ).concat(l), []).filter(t =>
+          t.endsWith('.breakpoint'),
+        ).length > 0;
 
       while (lastRow < e.getLineCount() && !isBreakpoint(lastRow) && nextRowText.match(re)) {
         code += `\n${nextRowText}`;
@@ -136,8 +138,8 @@ class PythonKernelMod {
       }
 
       onResults(msg, channel);
-      if (msg.header.msg_type == "execute_reply") {
-        if (this.enableVariableExplorer){
+      if (msg.header.msg_type == 'execute_reply') {
+        if (this.enableVariableExplorer) {
           this.variableExplorerHook(next);
         }
       }
@@ -162,14 +164,14 @@ class PythonKernelMod {
 
   wrapDataHandler(dataHandler) {
     return (msg, channel) => {
-      if (channel === "iopub"
-        && msg.header.msg_type === "display_data"
+      if (channel === 'iopub'
+        && msg.header.msg_type === 'display_data'
         && msg.content.data
         && msg.content.data['application/json']
         && msg.content.data['application/json'].hydrogen_python) {
-          dataHandler(msg.content.data['application/json'].hydrogen_python);
+        dataHandler(msg.content.data['application/json'].hydrogen_python);
       }
-    }
+    };
   }
 
   startKernelPluginInstall(next, onInstalled) {
@@ -177,11 +179,11 @@ class PythonKernelMod {
     const sanityCode = codeFromFile('sanity_check.py');
     const installCode = codeFromFile('install_kernel_plugin.py');
     next.execute(sanityCode, this.wrapDataHandler((data) => {
-      if (data !== "pass") {
+      if (data !== 'pass') {
         return;
       }
       next.execute(installCode, this.wrapDataHandler((data) => {
-        console.log("hydrogen-python: kernel plugin installed");
+        console.log('hydrogen-python: kernel plugin installed');
         this.kernelPluginInstalled = true;
         this.kernelPluginFailed = false;
         if (onInstalled) {
@@ -225,27 +227,27 @@ const HydrogenPythonPlugin = {
     this.subscriptions.add(this.emitter);
 
     this.subscriptions.add(
-      atom.workspace.addOpener(uri =>  {
-        switch(uri) {
+      atom.workspace.addOpener((uri) => {
+        switch (uri) {
           case VARIABLE_EXPLORER_URI:
             return new VariableExplorerPane(this.emitter);
         }
       }),
       // Destroy any Panes when the package is deactivated.
       new Disposable(() => {
-        atom.workspace.getPaneItems().forEach(item => {
+        atom.workspace.getPaneItems().forEach((item) => {
           if (item instanceof VariableExplorer) {
             item.destroy();
           }
         });
-      })
+      }),
     );
 
     this.subscriptions.add(
-      atom.commands.add("atom-text-editor:not([mini])", {
-        "hydrogen-python:toggle-variable-explorer": () =>
+      atom.commands.add('atom-text-editor:not([mini])', {
+        'hydrogen-python:toggle-variable-explorer': () =>
           atom.workspace.toggle(VARIABLE_EXPLORER_URI),
-      })
+      }),
     );
   },
 
@@ -256,10 +258,10 @@ const HydrogenPythonPlugin = {
   consumeHydrogen(hydrogen) {
     this.hydrogen = hydrogen;
 
-    this.hydrogen.onDidChangeKernel(kernel => {
-      if (kernel && kernel.language === "python" && !kernel[PLUGIN_KEY]) {
-        let kernelMod = new PythonKernelMod(kernel, this.emitter);
-        kernel[PLUGIN_KEY] = {mod: kernelMod};
+    this.hydrogen.onDidChangeKernel((kernel) => {
+      if (kernel && kernel.language === 'python' && !kernel[PLUGIN_KEY]) {
+        const kernelMod = new PythonKernelMod(kernel, this.emitter);
+        kernel[PLUGIN_KEY] = { mod: kernelMod };
       }
     });
 
@@ -271,11 +273,11 @@ const HydrogenPythonPlugin = {
 
 class VariableExplorerPane {
   reactElement = null;
-  element = document.createElement("div");
+  element = document.createElement('div');
   subscriptions = new CompositeDisposable();
 
   constructor(emitter) {
-    const reactElement = <VariableExplorer emitter={emitter} />
+    const reactElement = <VariableExplorer emitter={emitter} />;
 
     ReactDOM.render(reactElement, this.element);
     this.subscriptions.add(new Disposable(() => {
@@ -284,19 +286,19 @@ class VariableExplorerPane {
 
     emitter.emit('did-show-explorer');
     this.subscriptions.add(
-      emitter.on('did-install-middleware', ()=>{
+      emitter.on('did-install-middleware', () => {
         emitter.emit('did-show-explorer');
-      })
+      }),
     );
   }
 
-  getTitle = () => "Variable Explorer";
+  getTitle = () => 'Variable Explorer';
 
   getURI = () => VARIABLE_EXPLORER_URI;
 
-  getDefaultLocation = () => "right";
+  getDefaultLocation = () => 'right';
 
-  getAllowedLocations = () => ["left", "right", "bottom"];
+  getAllowedLocations = () => ['left', 'right', 'bottom'];
 
   destroy() {
     this.subscriptions.dispose();

--- a/lib/main.js
+++ b/lib/main.js
@@ -114,7 +114,7 @@ class PythonKernelMod {
           tt.split(' ').concat(ll), [],
         ).concat(l), []).includes('syntax--breakpoint');
 
-      while (!isBreakpoint(lastRow) && nextRowText.match(re)) {
+      while (lastRow < e.getLineCount() && !isBreakpoint(lastRow) && nextRowText.match(re)) {
         code += `\n${nextRowText}`;
         lastRow += 1;
         if (lastRow + 1 > e.getLastBufferRow()) break;

--- a/lib/main.js
+++ b/lib/main.js
@@ -106,7 +106,7 @@ class PythonKernelMod {
       const origRow = lastRow;
       let nextRowText = e.lineTextForBufferRow(lastRow + 1).replace(/\t/g, tabSub);
       const expandCode = [' '].concat(atom.config.get('hydrogen-python.expandCode')).join('|');
-      while (nextRowText.match(new RegExp(`^${indent}(${expandCode})`))) {
+      while (nextRowText.match(new RegExp(`^(${indent}(${expandCode})|\s*#)`))) {
         code += `\n${nextRowText}`;
         lastRow += 1;
         nextRowText = e.lineTextForBufferRow(lastRow + 1).replace(/\t/g, tabSub);

--- a/lib/main.js
+++ b/lib/main.js
@@ -63,6 +63,8 @@ function expandCode(editor, code) {
     return code;
   }
 
+  const originalCodeLength = code.split('\n').length;
+
   const bufferRowLength = editor.getLastBufferRow();
 
   // trim right to avoid empty lines at the end of the selection
@@ -87,6 +89,19 @@ function expandCode(editor, code) {
 
   // find original indent
   const indent = (code.match(/^\s+/) || '');
+
+  // prepare expansion regex to the top
+  const prependCodeList = atom.config.get('hydrogen-python.prependCodeList');
+  const prependCode = prependCodeList.join('|');
+  const prependRegex = new RegExp(`^(${indent}(${prependCode}))`);
+
+  // if start line matches the prepend code regex
+  // expand to first non-prepend line
+  let prependOffset = 0;
+  while (editor.lineTextForBufferRow(startBufferRow + prependOffset).match(prependRegex)) {
+    prependOffset += 1;
+    code += `\n${editor.lineTextForBufferRow(startBufferRow + prependOffset)}`;
+  }
 
   // function to identify breakpoints via tokens
   const isBreakpoint = rownum =>
@@ -114,7 +129,17 @@ function expandCode(editor, code) {
     if (lastRow + 1 > editor.getLastBufferRow()) break;
     nextRowText = editor.lineTextForBufferRow(lastRow + 1);
   }
-  if (origRow < lastRow) { console.log(`[hydrogen-python] expanded code by ${lastRow - origRow} lines up to line ${lastRow + 1}`); }
+
+  // expand code to the top
+  let prevRowText = (editor.lineTextForBufferRow(startBufferRow - 1) || '');
+  while (startBufferRow - 1 >= 0 && !isBreakpoint(startBufferRow - 1) && prevRowText.match(prependRegex)) {
+    code = `${prevRowText}\n${code}`;
+    startBufferRow -= 1;
+    if (startBufferRow <= 0) break;
+    prevRowText = editor.lineTextForBufferRow(startBufferRow - 1);
+  }
+
+  if (code.trimRight().split('\n').length > originalCodeLength) { console.log(`[hydrogen-python] executed code from line ${startBufferRow + 1} to line ${lastRow + 1}`); }
 
   // if run-and-move set cursor to the beginning of the next content line
   if (!isRunWithoutMove) {
@@ -122,7 +147,6 @@ function expandCode(editor, code) {
     while (bufferRow <= bufferRowLength && (editor.lineTextForBufferRow(bufferRow) || '').match(/^\s*($|#)/)) { bufferRow += 1; }
     editor.setCursorBufferPosition([(bufferRow == startBufferRow) ? (bufferRow + 1) : (bufferRow), 0]);
   }
-  console.log(code);
 
   return code;
 }

--- a/lib/main.js
+++ b/lib/main.js
@@ -79,51 +79,51 @@ class PythonKernelMod {
   execute(next, code, onResults) {
     let makeReply = null;
 
+    // trim right to avoid empty lines at the end of the selection
+    code = code.trimRight();
+
     // read editor settings
     const e = atom.workspace.getActiveTextEditor();
     const selection = e.getSelectedBufferRange();
     const isSelection = !selection.start.isEqual(selection.end);
     const isRunWithoutMove = (e.lineTextForBufferRow(selection.start.row) || '').includes(code.split('\n', 1)[0]);
-    const isRunWithMove = (e.lineTextForBufferRow(selection.start.row - code.split('\n').length) || '').includes(code.split('\n', 1)[0]);
-    if ((!isRunWithoutMove && !isRunWithMove) || isRunWithMove == isRunWithoutMove) {
-      console.warn('[hydrogen-python] Could not identify run-type properly.');
+
+    // find start of executed code
+    let startBufferRow = selection.start.row;
+    if (!isRunWithoutMove) {
+      const lastCodeLine = code.split('\n')[code.split('\n').length - 1];
+      while (!e.lineTextForBufferRow(startBufferRow).includes(lastCodeLine)) {
+        startBufferRow -= 1;
+        if (startBufferRow < 0) break;
+      }
+      startBufferRow = Math.max(0, startBufferRow - code.split('\n').length + 1);
     }
 
-    const startBufferRow = selection.start.row - ((isRunWithoutMove) ? 0 : (code.split('\n').length));
-    const tabSub = ' '.repeat(e.getTabLength());
+    // find original indent
+    const indent = (code.match(/^\s+/) || '');
 
-    // prepend original indent to code
-    let indent = e.lineTextForBufferRow(startBufferRow).match(/^\s+/) || '';
-    code = indent + code;
-    code = code.replace(/\t/g, tabSub);
-
-    // expand code to cover closing brackets and else/elif
+    // expand code if not a selection and item set
     if (!isSelection &&
         atom.config.get('hydrogen-python.expandCode').length > 0) {
       let lastRow = startBufferRow + (code.split('\n').length - 1);
       const origRow = lastRow;
-      let nextRowText = e.lineTextForBufferRow(lastRow + 1).replace(/\t/g, tabSub);
+      let nextRowText = (e.lineTextForBufferRow(lastRow + 1) || '');
       const expandCode = [' '].concat(atom.config.get('hydrogen-python.expandCode')).join('|');
-      while (nextRowText.match(new RegExp(`^(${indent}(${expandCode})|\s*#)`))) {
+      const re = new RegExp(`^(${indent}(${expandCode})|\s*#|\s*$)`);
+      while (nextRowText.match(re)) {
         code += `\n${nextRowText}`;
         lastRow += 1;
-        nextRowText = e.lineTextForBufferRow(lastRow + 1).replace(/\t/g, tabSub);
+        if (lastRow + 1 > e.getLastBufferRow()) break;
+        nextRowText = e.lineTextForBufferRow(lastRow + 1);
       }
       if (origRow < lastRow) { console.log(`[hydrogen-python] expanded code by ${lastRow - origRow} lines up to line ${lastRow + 1}`); }
     }
 
-    // strip all indentation
-    if (indent) {
-      code = code.replace(/(^\s+)/gm, (match) => {
-        if (indent === undefined) indent = match;
-        return match.replace(indent, '');
-      });
-    }
-
-    if (isRunWithMove) {
+    // if run-and-move set cursor to the beginning of the next content line
+    if (!isRunWithoutMove) {
       let bufferRow = startBufferRow + code.split('\n').length;
       while (bufferRow < e.getLineCount() && (e.lineTextForBufferRow(bufferRow) || '').match(/^\s*($|#)/)) { bufferRow += 1; }
-      e.setCursorBufferPosition([bufferRow, 0]);
+      e.setCursorBufferPosition([(bufferRow == startBufferRow) ? (bufferRow + 1) : (bufferRow), 0]);
     }
 
     next.execute(code, (msg, channel) => {

--- a/package.json
+++ b/package.json
@@ -38,13 +38,19 @@
     "eslint": "^3.9.1",
     "eslint-config-airbnb-base": "^10.0.1",
     "eslint-plugin-import": "^2.2.0"
-},
-"configSchema": {
-  "expandCode": {
-    "title": "[experimental] Expand code on indentation",
-    "type": "array",
-    "default": ["else", "elif", "\\}", "\\]", "\\)"],
-    "description": "When a line is executed without selection, hydrogen only passes on code up that is indented compared to the current line. This setting expands the executed code beyond what hydrogen suggests to include more statements, such as else, elif, or closing brackets on the same indentation level. *Warning:* The hydrogen tick markers are unfortunately _not_ moved to the right location."
+  },
+  "configSchema": {
+    "expandCode": {
+      "title": "[experimental] expand code",
+      "type": "boolean",
+      "default": "false",
+      "description": "When a line is executed without selection, hydrogen only passes on code up that is indented compared to the current line. Enabling this setting expands the executed code beyond what hydrogen suggests to include more statements, that can be defined below. *Warning:* The hydrogen tick markers are unfortunately _not_ moved to the right location."
+    },
+    "expandCodeList": {
+      "title": "Code to expand",
+      "type": "array",
+      "default": ["else", "elif", "\\}", "\\]", "\\)"],
+      "description": "If the above is enabled, this list will be passed on to a regex, so experts may define their own tokens. In the default setting, else, elif, as well as all closing braces are expanded on."
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,13 @@
       "title": "Code to Expand",
       "type": "array",
       "default": ["else", "elif", "except", "finally", "\\}", "\\]", "\\)"],
-      "description": "If the above setting is enabled, this list will be passed to a regex. Any of these items in the list can occur on th esame intentation level as the first line. You may define your own custom elements to modify the code to your preferred behaviour. In the default setting, else, elif, except, finally, as well as all closing braces are expanded on."
-    }
+      "description": "If the above setting is enabled, this list will be passed to a regex. Any of these items in the list need to occur on the same intentation level as the first line. You may define your own custom elements to modify the code to your preferred behaviour. In the default setting, else, elif, except, finally, as well as all closing braces are expanded on."
+  },
+  "prependCodeList": {
+    "title": "Code to Expand Before the Execution",
+    "type": "array",
+    "default": ["@"],
+    "description": "If the above setting is enabled, this list will be passed to a regex. Any of these items in the list need to occur on the same intentation level as the first line. You may define your own custom elements to modify the code to your preferred behaviour. In the default setting, the @ decorator is prepended."
+  }
   }
 }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "expandCodeList": {
       "title": "Code to expand",
       "type": "array",
-      "default": ["else", "elif", "\\}", "\\]", "\\)"],
+      "default": ["else", "elif", "except", "finally", "\\}", "\\]", "\\)"],
       "description": "If the above is enabled, this list will be passed on to a regex, so experts may define their own tokens. In the default setting, else, elif, as well as all closing braces are expanded on."
     }
   }

--- a/package.json
+++ b/package.json
@@ -41,16 +41,16 @@
   },
   "configSchema": {
     "expandCode": {
-      "title": "[experimental] expand code",
+      "title": "Extend Executable Code [experimental]",
       "type": "boolean",
       "default": "false",
-      "description": "When a line is executed without selection, hydrogen only passes on code up that is indented compared to the current line. Enabling this setting expands the executed code beyond what hydrogen suggests to include more statements, that can be defined below. *Warning:* The hydrogen tick markers are unfortunately _not_ moved to the right location."
+      "description": "When a line is executed without selection, hydrogen only passes on code up that is indented compared to the current line. In python that unfortunately does not always work, because some control structures (e.g. else) continue on the same indentation level. Enabling this setting expands the executed code beyond what hydrogen suggests on the basis of the indentation level. The statements which trigger such extension can be defined below. *Warning:* The hydrogen tick markers are unfortunately _not_ moved to the right location."
     },
     "expandCodeList": {
-      "title": "Code to expand",
+      "title": "Code to Expand",
       "type": "array",
       "default": ["else", "elif", "except", "finally", "\\}", "\\]", "\\)"],
-      "description": "If the above is enabled, this list will be passed on to a regex, so experts may define their own tokens. In the default setting, else, elif, as well as all closing braces are expanded on."
+      "description": "If the above setting is enabled, this list will be passed to a regex. Any of these items in the list can occur on th esame intentation level as the first line. You may define your own custom elements to modify the code to your preferred behaviour. In the default setting, else, elif, except, finally, as well as all closing braces are expanded on."
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,5 +38,13 @@
     "eslint": "^3.9.1",
     "eslint-config-airbnb-base": "^10.0.1",
     "eslint-plugin-import": "^2.2.0"
+},
+"configSchema": {
+  "expandCode": {
+    "title": "[experimental] Expand code on indentation",
+    "type": "array",
+    "default": ["else", "elif", "\\}", "\\]", "\\)"],
+    "description": "When a line is executed without selection, hydrogen only passes on code up that is indented compared to the current line. This setting expands the executed code beyond what hydrogen suggests to include more statements, such as else, elif, or closing brackets on the same indentation level. *Warning:* The hydrogen tick markers are unfortunately _not_ moved to the right location."
+    }
   }
 }


### PR DESCRIPTION
Should solve #3 in line with what @nikitakit mentioned in nteract/hydrogen#862.
It reads the first line of the selection and appends the indentation to the code passed.
This removes both limitations mentioned in the README.

Further solves nteract/hydrogen#1341 and nteract/hydrogen#1344 I believe.
However, I couldn't find a way to move the tick bubble to the correct line (except for adding a watch and moving it by cheating).
It expands the code line by line if certain (configurable) keywords are found.
Maybe you have an idea about the tickbox?