### PR TITLE
fix wrong run-and-move-down behaviour (#16)

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -80,7 +80,7 @@ function expandCode(editor, code) {
   // find start of executed code
   let startBufferRow = selection.start.row;
   if (!isRunWithoutMove) {
-    while (!editor.lineTextForBufferRow(startBufferRow).includes(lastCodeLineText)) {
+    while (editor.lineTextForBufferRow(startBufferRow).trim() != lastCodeLineText.trim())) {
       startBufferRow -= 1;
       if (startBufferRow < 0) break;
     }

--- a/lib/main.js
+++ b/lib/main.js
@@ -80,7 +80,7 @@ function expandCode(editor, code) {
   // find start of executed code
   let startBufferRow = selection.start.row;
   if (!isRunWithoutMove) {
-    while (editor.lineTextForBufferRow(startBufferRow).trim() != lastCodeLineText.trim())) {
+    while (editor.lineTextForBufferRow(startBufferRow).trim() != lastCodeLineText.trim()) {
       startBufferRow -= 1;
       if (startBufferRow < 0) break;
     }


### PR DESCRIPTION
Fixes #16.
Changed an includes-statement to an actual comparison.

(What an odyssey, thanks @kylebarron for your help!)