### PR TITLE
fix null reference on empty cell. fixes #14

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -183,7 +183,9 @@ class PythonKernelMod {
     // is indented the same amount. However, this only works if the first line
     // is indented. We therefore trim empty lines at the start of the executed
     // region.
-    code = code.replace(/^\n|\n$/g, '');
+    if (code != null) {
+      code = code.replace(/^\n|\n$/g, '');
+    }
 
     next.execute(code, (msg, channel) => {
       if (!makeReply && msg.parent_header) {


### PR DESCRIPTION
if the file contains a trailing code block marker (`# %%`) there will be an empty cell passed to execute with code null. This seems to be the expected behaviour from hydrogen since it explicitly adds a cell ending at file ending.